### PR TITLE
feat: support wasm target build

### DIFF
--- a/sudachi/src/dic/dictionary.rs
+++ b/sudachi/src/dic/dictionary.rs
@@ -41,12 +41,12 @@ use crate::plugin::Plugins;
 // This structure is always read only after creation and is safe to share
 // between threads.
 pub struct JapaneseDictionary {
-    storage: SudachiDicData,
-    plugins: Plugins,
+    pub storage: SudachiDicData,
+    pub plugins: Plugins,
     //'static is a a lie, lifetime is the same with StorageBackend
-    _grammar: Grammar<'static>,
+    pub _grammar: Grammar<'static>,
     //'static is a a lie, lifetime is the same with StorageBackend
-    _lexicon: LexiconSet<'static>,
+    pub _lexicon: LexiconSet<'static>,
 }
 
 fn map_file(path: &Path) -> SudachiResult<Storage> {

--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -14,12 +14,16 @@
  *  limitations under the License.
  */
 
+#[cfg(target_family = "wasm")]
+type Library = ();
+#[cfg(not(target_family = "wasm"))]
 use libloading::{Library, Symbol};
 use serde_json::Value;
 
 use crate::config::{Config, ConfigError};
 use crate::dic::grammar::Grammar;
 use crate::error::{SudachiError, SudachiResult};
+#[cfg(not(target_family = "wasm"))]
 use crate::plugin::PluginError;
 
 /// Holds loaded plugins, whether they are bundled
@@ -67,6 +71,7 @@ fn make_system_specific_name(s: &str) -> String {
     format!("lib{}.dylib", s)
 }
 
+#[cfg(not(target_family = "wasm"))]
 fn system_specific_name(s: &str) -> Option<String> {
     if s.contains('.') {
         None
@@ -123,8 +128,9 @@ impl<'a, 'b, T: PluginCategory + ?Sized> PluginLoader<'a, 'b, T> {
                 }
             // Otherwise treat name as DSO
             } else {
-                let candidates = self.resolve_dso_names(name);
-                self.load_plugin_from_dso(&candidates)?
+                todo!()
+                // let candidates = self.resolve_dso_names(name);
+                // self.load_plugin_from_dso(&candidates)?
             };
 
         <T as PluginCategory>::do_setup(&mut plugin, plugin_cfg, &self.cfg, &mut self.grammar)
@@ -133,6 +139,7 @@ impl<'a, 'b, T: PluginCategory + ?Sized> PluginLoader<'a, 'b, T> {
         Ok(())
     }
 
+    #[cfg(not(target_family = "wasm"))]
     fn resolve_dso_names(&self, name: &str) -> Vec<String> {
         let mut resolved = self.cfg.resolve_paths(name.to_owned());
 
@@ -144,6 +151,7 @@ impl<'a, 'b, T: PluginCategory + ?Sized> PluginLoader<'a, 'b, T> {
         resolved
     }
 
+    #[cfg(not(target_family = "wasm"))]
     fn try_load_library_from(candidates: &[String]) -> SudachiResult<(Library, &str)> {
         if candidates.is_empty() {
             return Err(SudachiError::PluginError(PluginError::InvalidDataFormat(
@@ -164,6 +172,7 @@ impl<'a, 'b, T: PluginCategory + ?Sized> PluginLoader<'a, 'b, T> {
         }))
     }
 
+    #[cfg(not(target_family = "wasm"))]
     fn load_plugin_from_dso(
         &mut self,
         candidates: &[String],

--- a/sudachi/src/plugin/loader.rs
+++ b/sudachi/src/plugin/loader.rs
@@ -14,10 +14,10 @@
  *  limitations under the License.
  */
 
-#[cfg(target_family = "wasm")]
-type Library = ();
 #[cfg(not(target_family = "wasm"))]
 use libloading::{Library, Symbol};
+#[cfg(target_family = "wasm")]
+type Library = ();
 use serde_json::Value;
 
 use crate::config::{Config, ConfigError};

--- a/sudachi/src/plugin/mod.rs
+++ b/sudachi/src/plugin/mod.rs
@@ -59,18 +59,15 @@ impl From<LLError> for PluginError {
     }
 }
 
-pub(crate) struct Plugins {
-    pub(crate) connect_cost: PluginContainer<dyn EditConnectionCostPlugin>,
+pub struct Plugins {
+    pub connect_cost: PluginContainer<dyn EditConnectionCostPlugin>,
     pub(crate) input_text: PluginContainer<dyn InputTextPlugin>,
-    pub(crate) oov: PluginContainer<dyn OovProviderPlugin>,
+    pub oov: PluginContainer<dyn OovProviderPlugin>,
     pub(crate) path_rewrite: PluginContainer<dyn PathRewritePlugin>,
 }
 
 impl Plugins {
-    pub(crate) fn load<'a, 'b>(
-        cfg: &'a Config,
-        grammar: &'a mut Grammar<'b>,
-    ) -> SudachiResult<Plugins>
+    pub fn load<'a, 'b>(cfg: &'a Config, grammar: &'a mut Grammar<'b>) -> SudachiResult<Plugins>
     where
         'b: 'a,
     {

--- a/sudachi/src/util/fxhash.rs
+++ b/sudachi/src/util/fxhash.rs
@@ -55,6 +55,8 @@ const ROTATE: u32 = 5;
 const SEED64: u64 = 0x51_7c_c1_b7_27_22_0a_95;
 const SEED32: u32 = 0x9e_37_79_b9;
 
+#[cfg(target_pointer_width = "32")]
+const SEED: usize = SEED32 as usize;
 #[cfg(target_pointer_width = "64")]
 const SEED: usize = SEED64 as usize;
 


### PR DESCRIPTION
- for https://github.com/hi-ogawa/japanese-line-break-segmenter/pull/7

## todo

- [x] dictionary does memory map, so it probably needs to be replaces with something.
- [ ] add "feature" to disable shared library plugin system (instead of relying on `target_family = "wasm"`
  - cf. `cfg_attr path` switch https://github.com/RazrFalcon/memmap2-rs/blob/64cf17da2b22fd6fbe6f86346b18906025487891/src/lib.rs#L39-L42